### PR TITLE
RU translation improvement

### DIFF
--- a/src/preload/commands/pushkart/index.ts
+++ b/src/preload/commands/pushkart/index.ts
@@ -48,9 +48,9 @@ export default class PushCart extends Command {
                 / 1000
             );
 
-            return await this.fail(msg, `Вы должны подождать 30 секунд, прежде чем снова нажать тележку (${secondsRemaining} осталось).`);
+            return await this.fail(msg, `Вы должны подождать 30 секунд, прежде чем снова толкать тележку (${secondsRemaining} осталось).`);
         } else if (pushResult == "CAP") {
-            return await this.fail(msg, "Вы набрали максимальное количество баллов за сегодня. Вернуться завтра!");
+            return await this.fail(msg, "Вы набрали максимальное количество баллов за сегодня. Возвращайтесь завтра!");
         }
 
         server.addCartFeet(feetPushed);


### PR DESCRIPTION
Нажать = press, changed to push

Вернуться - to come back, (inf form), which can't be used there.

Whole thing still seems google translate-y, but at least there are no misused words now. Might rewrite it to something more "natural" later 

Source - am russian